### PR TITLE
Add JSON Source Gen

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,8 @@
 <Project>
   <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <CurrentPreviewTfm>net8.0</CurrentPreviewTfm>
+    <IncludePreview Condition=" '$(IncludePreview)' == ''">false</IncludePreview>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
   <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
   <PropertyGroup>
     <CurrentPreviewTfm>net8.0</CurrentPreviewTfm>
+    <!--<IncludePreview>true</IncludePreview>-->
     <IncludePreview Condition=" '$(IncludePreview)' == ''">false</IncludePreview>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -11,7 +12,7 @@
   <PropertyGroup>
     <PasswordlessMajorVersion>1</PasswordlessMajorVersion>
     <PasswordlessMinorVersion>0</PasswordlessMinorVersion>
-    <PasswordlessPatchVersion>1</PasswordlessPatchVersion>
+    <PasswordlessPatchVersion>2</PasswordlessPatchVersion>
     <PasswordlessMajorMinorVersion>$(PasswordlessMajorVersion).$(PasswordlessMinorVersion)</PasswordlessMajorMinorVersion>
     <VersionPrefix>$(PasswordlessMajorMinorVersion).$(PasswordlessPatchVersion)</VersionPrefix>
   </PropertyGroup>

--- a/src/Sdk/Base64Url.cs
+++ b/src/Sdk/Base64Url.cs
@@ -15,7 +15,7 @@ internal static class Base64Url
 
 #if NET5_0_OR_GREATER
         Convert.TryToBase64Chars(arg, array, out var charsWritten);
-#elif NET462
+#elif NET462 || NETSTANDARD2_0
         var charsWritten = Convert.ToBase64CharArray(arg.ToArray(), 0, minimumLength, array, 0);
 #endif
         Span<char> span = array.AsSpan(0, charsWritten);
@@ -42,7 +42,7 @@ internal static class Base64Url
 
 #if NET5_0_OR_GREATER
         string result = new string(span);
-#elif NET462
+#elif NET462 || NETSTANDARD2_0
         string result = new string(span.ToArray());
 #endif
         ArrayPool<char>.Shared.Return(array, clearArray: true);

--- a/src/Sdk/Helpers/Json.cs
+++ b/src/Sdk/Helpers/Json.cs
@@ -1,8 +1,0 @@
-using System.Text.Json;
-
-namespace Passwordless.Net.Helpers;
-
-internal static class Json
-{
-    public static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
-}

--- a/src/Sdk/Helpers/PasswordlessSerializerContext.cs
+++ b/src/Sdk/Helpers/PasswordlessSerializerContext.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Passwordless.Net.Models;
+
+namespace Passwordless.Net.Helpers;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(RegisterTokenResponse))]
+[JsonSerializable(typeof(RegisterOptions))]
+[JsonSerializable(typeof(VerifyTokenRequest))] // TODO: Use this with JsonContent.Create
+[JsonSerializable(typeof(VerifiedUser))]
+[JsonSerializable(typeof(DeleteUserRequest))]
+[JsonSerializable(typeof(ListResponse<PasswordlessUserSummary>))]
+[JsonSerializable(typeof(ListResponse<AliasPointer>))]
+[JsonSerializable(typeof(ListResponse<Credential>))]
+[JsonSerializable(typeof(DeleteCredentialRequest))]
+[JsonSerializable(typeof(UsersCount))]
+[JsonSerializable(typeof(PasswordlessProblemDetails))]
+[JsonSerializable(typeof(Dictionary<string, JsonElement>))]
+[JsonSerializable(typeof(JsonElement))]
+internal partial class PasswordlessSerializerContext : JsonSerializerContext
+{
+
+}

--- a/src/Sdk/IPasswordlessClient.cs
+++ b/src/Sdk/IPasswordlessClient.cs
@@ -59,7 +59,7 @@ public interface IPasswordlessClient
     /// <param name="cancellationToken"></param>
     /// <returns>A task object representing the asynchronous operation containing the <see cref="IReadOnlyList{PasswordlessUserSummary}" />.</returns>
     /// <exception cref="PasswordlessApiException">An exception containing details abaout the reason for failure.</exception>
-    Task<IReadOnlyList<PasswordlessUserSummary>?> ListUsersAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<PasswordlessUserSummary>> ListUsersAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Verifies that the given token is valid and returns information packed into it. The token should have been generated

--- a/src/Sdk/Models/AliasPointer.cs
+++ b/src/Sdk/Models/AliasPointer.cs
@@ -2,7 +2,14 @@
 
 public class AliasPointer
 {
-    public string UserId { get; set; }
-    public string Alias { get; set; }
-    public string Plaintext { get; set; }
+    public AliasPointer(string userId, string alias, string plaintext)
+    {
+        UserId = userId;
+        Alias = alias;
+        Plaintext = plaintext;
+    }
+
+    public string UserId { get; }
+    public string Alias { get; }
+    public string Plaintext { get; }
 }

--- a/src/Sdk/Models/AuditLog.cs
+++ b/src/Sdk/Models/AuditLog.cs
@@ -1,9 +1,0 @@
-﻿namespace Passwordless.Net;
-
-public class AuditLog
-{
-    public DateTime Timestamp { get; set; }
-    public string Level { get; set; }
-    public string Message { get; set; }
-    public string Details { get; set; }
-}

--- a/src/Sdk/Models/Credential.cs
+++ b/src/Sdk/Models/Credential.cs
@@ -2,18 +2,38 @@
 
 public class Credential
 {
-    public CredentialDescriptor Descriptor { get; set; }
-    public byte[] PublicKey { get; set; }
-    public byte[] UserHandle { get; set; }
-    public uint SignatureCounter { get; set; }
-    public string AttestationFmt { get; set; }
-    public DateTime CreatedAt { get; set; }
-    public Guid AaGuid { get; set; }
-    public DateTime LastUsedAt { get; set; }
-    public string RPID { get; set; }
-    public string Origin { get; set; }
-    public string Country { get; set; }
-    public string Device { get; set; }
-    public string Nickname { get; set; }
-    public string UserId { get; set; }
+    public Credential(CredentialDescriptor descriptor, byte[] publicKey, byte[] userHandle, uint signatureCounter,
+        string attestationFmt, DateTime createdAt, Guid aaGuid, DateTime lastUsedAt, string rpid,
+        string origin, string country, string device, string nickname, string userId)
+    {
+        Descriptor = descriptor;
+        PublicKey = publicKey;
+        UserHandle = userHandle;
+        SignatureCounter = signatureCounter;
+        AttestationFmt = attestationFmt;
+        CreatedAt = createdAt;
+        AaGuid = aaGuid;
+        LastUsedAt = lastUsedAt;
+        RPID = rpid;
+        Origin = origin;
+        Country = country;
+        Device = device;
+        Nickname = nickname;
+        UserId = userId;
+    }
+
+    public CredentialDescriptor Descriptor { get; }
+    public byte[] PublicKey { get; }
+    public byte[] UserHandle { get; }
+    public uint SignatureCounter { get; }
+    public string AttestationFmt { get; }
+    public DateTime CreatedAt { get; }
+    public Guid AaGuid { get; }
+    public DateTime LastUsedAt { get; }
+    public string RPID { get; }
+    public string Origin { get; }
+    public string Country { get; }
+    public string Device { get; }
+    public string Nickname { get; }
+    public string UserId { get; }
 }

--- a/src/Sdk/Models/CredentialDescriptor.cs
+++ b/src/Sdk/Models/CredentialDescriptor.cs
@@ -1,11 +1,14 @@
 ﻿using System.Text.Json.Serialization;
 
-using static Passwordless.Net.PasswordlessClient;
-
 namespace Passwordless.Net;
 
 public class CredentialDescriptor
 {
+    public CredentialDescriptor(byte[] id)
+    {
+        Id = id;
+    }
+
     [JsonConverter(typeof(Base64UrlConverter))]
     public byte[] Id { get; set; }
 }

--- a/src/Sdk/Models/DeleteCredentialRequest.cs
+++ b/src/Sdk/Models/DeleteCredentialRequest.cs
@@ -1,0 +1,11 @@
+namespace Passwordless.Net.Models;
+
+internal class DeleteCredentialRequest
+{
+    public DeleteCredentialRequest(string credentialId)
+    {
+        CredentialId = credentialId;
+    }
+
+    public string CredentialId { get; }
+}

--- a/src/Sdk/Models/DeleteUserRequest.cs
+++ b/src/Sdk/Models/DeleteUserRequest.cs
@@ -1,0 +1,11 @@
+namespace Passwordless.Net.Models;
+
+internal class DeleteUserRequest
+{
+    public DeleteUserRequest(string userId)
+    {
+        UserId = userId;
+    }
+
+    public string UserId { get; }
+}

--- a/src/Sdk/Models/PasswordlessUserSummary.cs
+++ b/src/Sdk/Models/PasswordlessUserSummary.cs
@@ -2,9 +2,19 @@ namespace Passwordless.Net;
 
 public class PasswordlessUserSummary
 {
-    public string UserId { get; set; }
-    public List<string> Aliases { get; set; }
-    public int CredentialsCount { get; set; }
-    public int AliasCount { get; set; }
-    public DateTime? LastUsedAt { get; set; }
+    public PasswordlessUserSummary(string userId, IReadOnlyList<string> aliases, int credentialsCount,
+        int aliasCount, DateTime? lastUsedAt)
+    {
+        UserId = userId;
+        Aliases = aliases;
+        CredentialsCount = credentialsCount;
+        AliasCount = aliasCount;
+        LastUsedAt = lastUsedAt;
+    }
+
+    public string UserId { get; }
+    public IReadOnlyList<string> Aliases { get; }
+    public int CredentialsCount { get; }
+    public int AliasCount { get; }
+    public DateTime? LastUsedAt { get; }
 }

--- a/src/Sdk/Models/RegisterOptions.cs
+++ b/src/Sdk/Models/RegisterOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Passwordless.Net;
+﻿using System.Text.Json.Serialization;
+
+namespace Passwordless.Net;
 
 /// <summary>
 /// 

--- a/src/Sdk/Models/RegisterTokenResponse.cs
+++ b/src/Sdk/Models/RegisterTokenResponse.cs
@@ -1,6 +1,13 @@
-﻿namespace Passwordless.Net.Models;
+﻿using System.Text.Json.Serialization;
+
+namespace Passwordless.Net.Models;
 
 public class RegisterTokenResponse
 {
-    public string Token { get; set; }
+    public RegisterTokenResponse(string token)
+    {
+        Token = token;
+    }
+
+    public string Token { get; }
 }

--- a/src/Sdk/Models/UsersCount.cs
+++ b/src/Sdk/Models/UsersCount.cs
@@ -2,5 +2,10 @@ namespace Passwordless.Net;
 
 public class UsersCount
 {
-    public int Count { get; set; }
+    public UsersCount(int count)
+    {
+        Count = count;
+    }
+
+    public int Count { get; }
 }

--- a/src/Sdk/Models/VerifiedUser.cs
+++ b/src/Sdk/Models/VerifiedUser.cs
@@ -2,16 +2,34 @@
 
 public class VerifiedUser
 {
-    public string UserId { get; set; }
-    public byte[] CredentialId { get; set; }
-    public bool Success { get; set; }
-    public DateTime Timestamp { get; set; }
-    public string RpId { get; set; }
-    public string Origin { get; set; }
-    public string Device { get; set; }
-    public string Country { get; set; }
-    public string Nickname { get; set; }
-    public DateTime ExpiresAt { get; set; }
-    public Guid TokenId { get; set; }
-    public string Type { get; set; }
+    public VerifiedUser(string userId, byte[] credentialId, bool success,
+        DateTime timestamp, string rpId, string origin, string device,
+        string country, string nickname, DateTime expiresAt, Guid tokenId,
+        string type)
+    {
+        UserId = userId;
+        CredentialId = credentialId;
+        Success = success;
+        Timestamp = timestamp;
+        RpId = rpId;
+        Origin = origin;
+        Device = device;
+        Country = country;
+        Nickname = nickname;
+        ExpiresAt = expiresAt;
+        TokenId = tokenId;
+        Type = type;
+    }
+    public string UserId { get; }
+    public byte[] CredentialId { get; }
+    public bool Success { get; }
+    public DateTime Timestamp { get; }
+    public string RpId { get; }
+    public string Origin { get; }
+    public string Device { get; }
+    public string Country { get; }
+    public string Nickname { get; }
+    public DateTime ExpiresAt { get; }
+    public Guid TokenId { get; }
+    public string Type { get; }
 }

--- a/src/Sdk/Models/VerifyTokenRequest.cs
+++ b/src/Sdk/Models/VerifyTokenRequest.cs
@@ -1,0 +1,11 @@
+namespace Passwordless.Net.Models;
+
+internal class VerifyTokenRequest
+{
+    public VerifyTokenRequest(string token)
+    {
+        Token = token;
+    }
+
+    public string Token { get; }
+}

--- a/src/Sdk/PasswordlessApiException.cs
+++ b/src/Sdk/PasswordlessApiException.cs
@@ -1,28 +1,39 @@
+using System.Diagnostics;
 using System.Net.Http;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Passwordless.Net;
 
 public sealed class PasswordlessApiException : HttpRequestException
 {
-    public ProblemDetails Details { get; }
+    public PasswordlessProblemDetails Details { get; }
 
-    public PasswordlessApiException(ProblemDetails problemDetails) : base(problemDetails.Title)
+    public PasswordlessApiException(PasswordlessProblemDetails problemDetails) : base(problemDetails.Title)
     {
         Details = problemDetails;
     }
 }
 
-public class ProblemDetails
+public class PasswordlessProblemDetails
 {
-    // TODO: Make immutable
+    public PasswordlessProblemDetails(string type,
+        string title, int status, string? detail, string? instance)
+    {
+        Type = type;
+        Title = title;
+        Status = status;
+        Detail = detail;
+        Instance = instance;
+    }
+
     // TODO: Include errorCode as a property once it's more common
-    public string Type { get; set; } = null!;
-    public string Title { get; set; } = null!;
-    public int Status { get; set; }
-    public string? Detail { get; set; }
-    public string? Instance { get; set; }
+    public string Type { get; }
+    public string Title { get; }
+    public int Status { get; }
+    public string? Detail { get; }
+    public string? Instance { get; }
 
     [JsonExtensionData]
-    public Dictionary<string, object?> Extensions { get; set; }
+    public Dictionary<string, JsonElement> Extensions { get; set; } = new Dictionary<string, JsonElement>();
 }

--- a/src/Sdk/PasswordlessClient.cs
+++ b/src/Sdk/PasswordlessClient.cs
@@ -2,7 +2,9 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text;
+using Passwordless.Net.Helpers;
 using Passwordless.Net.Models;
+using JsonContext = Passwordless.Net.Helpers.PasswordlessSerializerContext;
 
 namespace Passwordless.Net;
 
@@ -42,9 +44,14 @@ public class PasswordlessClient : IPasswordlessClient, IDisposable
     /// <inheritdoc/>
     public async Task<RegisterTokenResponse> CreateRegisterTokenAsync(RegisterOptions registerOptions, CancellationToken cancellationToken = default)
     {
-        var res = await _client.PostAsJsonAsync("register/token", registerOptions, cancellationToken);
+        var res = await _client.PostAsJsonAsync("register/token",
+            registerOptions,
+            JsonContext.Default.RegisterOptions,
+            cancellationToken);
         res.EnsureSuccessStatusCode();
-        return (await res.Content.ReadFromJsonAsync<RegisterTokenResponse>(options: null, cancellationToken))!;
+        return (await res.Content.ReadFromJsonAsync<RegisterTokenResponse>(
+            JsonContext.Default.RegisterTokenResponse,
+            cancellationToken))!;
     }
 
     /// <inheritdoc/>
@@ -52,10 +59,8 @@ public class PasswordlessClient : IPasswordlessClient, IDisposable
     {
         var request = new HttpRequestMessage(HttpMethod.Post, "signin/verify")
         {
-            Content = JsonContent.Create(new
-            {
-                token = verifyToken,
-            }),
+            // TODO: No JsonTypeInfo overload yet?
+            Content = JsonContent.Create(new VerifyTokenRequest(verifyToken)),
         };
 
         // We just want to return null if there is a problem.
@@ -64,7 +69,9 @@ public class PasswordlessClient : IPasswordlessClient, IDisposable
 
         if (response.IsSuccessStatusCode)
         {
-            var res = await response.Content.ReadFromJsonAsync<VerifiedUser>();
+            var res = await response.Content.ReadFromJsonAsync(
+                JsonContext.Default.VerifiedUser,
+                cancellationToken);
             return res;
         }
 
@@ -74,34 +81,49 @@ public class PasswordlessClient : IPasswordlessClient, IDisposable
     /// <inheritdoc/>
     public async Task DeleteUserAsync(string userId, CancellationToken cancellationToken = default)
     {
-        await _client.PostAsJsonAsync("users/delete", new { UserId = userId }, cancellationToken);
+        await _client.PostAsJsonAsync("users/delete",
+            new DeleteUserRequest(userId),
+            JsonContext.Default.DeleteUserRequest,
+            cancellationToken);
     }
 
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<PasswordlessUserSummary>?> ListUsersAsync(CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<PasswordlessUserSummary>> ListUsersAsync(CancellationToken cancellationToken = default)
     {
-        var response = await _client.GetFromJsonAsync<ListResponse<PasswordlessUserSummary>>("users/list", cancellationToken);
+        var response = await _client.GetFromJsonAsync(
+            "users/list",
+            JsonContext.Default.ListResponsePasswordlessUserSummary,
+            cancellationToken);
         return response!.Values;
     }
 
     /// <inheritdoc/>
     public async Task<IReadOnlyList<AliasPointer>> ListAliasesAsync(string userId, CancellationToken cancellationToken = default)
     {
-        var response = await _client.GetFromJsonAsync<ListResponse<AliasPointer>>($"alias/list?userid={userId}", cancellationToken);
+        var response = await _client.GetFromJsonAsync(
+            $"alias/list?userid={userId}",
+            JsonContext.Default.ListResponseAliasPointer,
+            cancellationToken);
         return response!.Values;
     }
 
     /// <inheritdoc/>
     public async Task<IReadOnlyList<Credential>> ListCredentialsAsync(string userId, CancellationToken cancellationToken = default)
     {
-        var response = await _client.GetFromJsonAsync<ListResponse<Credential>>($"credentials/list?userid={userId}", cancellationToken);
+        var response = await _client.GetFromJsonAsync(
+            $"credentials/list?userid={userId}",
+            JsonContext.Default.ListResponseCredential,
+            cancellationToken);
         return response!.Values;
     }
 
     /// <inheritdoc/>
     public async Task DeleteCredentialAsync(string id, CancellationToken cancellationToken = default)
     {
-        await _client.PostAsJsonAsync("credentials/delete", new { CredentialId = id }, cancellationToken);
+        await _client.PostAsJsonAsync("credentials/delete",
+            new DeleteCredentialRequest(id),
+            JsonContext.Default.DeleteCredentialRequest,
+            cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -112,7 +134,10 @@ public class PasswordlessClient : IPasswordlessClient, IDisposable
 
     public async Task<UsersCount> GetUsersCountAsync(CancellationToken cancellationToken = default)
     {
-        return (await _client.GetFromJsonAsync<UsersCount>("users/count", cancellationToken))!;
+        return (await _client.GetFromJsonAsync(
+            "users/count",
+            JsonContext.Default.UsersCount,
+            cancellationToken))!;
     }
 
     private string DebuggerToString()

--- a/src/Sdk/PasswordlessDelegatingHandler.cs
+++ b/src/Sdk/PasswordlessDelegatingHandler.cs
@@ -19,7 +19,9 @@ internal class PasswordlessDelegatingHandler : DelegatingHandler
             && string.Equals(response.Content.Headers.ContentType?.MediaType, "application/problem+json", StringComparison.OrdinalIgnoreCase))
         {
             // Attempt to read problem details
-            var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>(Json.Options, cancellationToken: cancellationToken);
+            var problemDetails = await response.Content.ReadFromJsonAsync(
+                PasswordlessSerializerContext.Default.PasswordlessProblemDetails,
+                cancellationToken);
 
             // Throw exception
             throw new PasswordlessApiException(problemDetails!);

--- a/src/Sdk/PasswordlessHttpRequestExtensions.cs
+++ b/src/Sdk/PasswordlessHttpRequestExtensions.cs
@@ -6,7 +6,7 @@ internal static class PasswordlessHttpRequestExtensions
 {
 #if NET5_0_OR_GREATER
     internal static HttpRequestOptionsKey<bool> SkipErrorHandlingOption = new(nameof(SkipErrorHandling));
-#elif NET462
+#elif NET462 || NETSTANDARD2_0
     internal const string SkipErrorHandlingOption = nameof(SkipErrorHandling);
 #endif
 
@@ -14,7 +14,7 @@ internal static class PasswordlessHttpRequestExtensions
     {
 #if NET5_0_OR_GREATER
         request.Options.Set(SkipErrorHandlingOption, skip);
-#elif NET462
+#elif NET462 || NETSTANDARD2_0
         request.Properties[SkipErrorHandlingOption] = skip;
 #endif
         return request;
@@ -24,7 +24,7 @@ internal static class PasswordlessHttpRequestExtensions
     {
 #if NET5_0_OR_GREATER
         return request.Options.TryGetValue(SkipErrorHandlingOption, out var doNotErrorHandle) && doNotErrorHandle;
-#elif NET462
+#elif NET462 || NETSTANDARD2_0
         return request.Properties.TryGetValue(SkipErrorHandlingOption, out var shouldSkipOptionObject)
             && shouldSkipOptionObject is bool shouldSkipOption
             && shouldSkipOption;

--- a/src/Sdk/Pollyfill.cs
+++ b/src/Sdk/Pollyfill.cs
@@ -1,0 +1,143 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#if INCLUDE_DYNAMICALLY_ACCESSED_MEMBERS
+    /// <summary>
+    /// Indicates that certain members on a specified <see cref="Type"/> are accessed dynamically,
+    /// for example through <see cref="Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which members are being accessed during the execution
+    /// of a program.
+    ///
+    /// This attribute is valid on members whose type is <see cref="Type"/> or <see cref="string"/>.
+    ///
+    /// When this attribute is applied to a location of type <see cref="string"/>, the assumption is
+    /// that the string represents a fully qualified type name.
+    ///
+    /// When this attribute is applied to a class, interface, or struct, the members specified
+    /// can be accessed dynamically on <see cref="Type"/> instances returned from calling
+    /// <see cref="object.GetType"/> on instances of that class, interface, or struct.
+    ///
+    /// If the attribute is applied to a method it's treated as a special case and it implies
+    /// the attribute should be applied to the "this" parameter of the method. As such the attribute
+    /// should only be used on instance methods of types assignable to System.Type (or string, but no methods
+    /// will use it there).
+    /// </remarks>
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method |
+        AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+        Inherited = false)]
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// with the specified member types.
+        /// </summary>
+        /// <param name="memberTypes">The types of members dynamically accessed.</param>
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members dynamically accessed.
+        /// </summary>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    /// <summary>
+    /// Specifies the types of members that are dynamically accessed.
+    ///
+    /// This enumeration has a <see cref="FlagsAttribute"/> attribute that allows a
+    /// bitwise combination of its member values.
+    /// </summary>
+    [Flags]
+    internal enum DynamicallyAccessedMemberTypes
+    {
+        /// <summary>
+        /// Specifies no members.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Specifies the default, parameterless public constructor.
+        /// </summary>
+        PublicParameterlessConstructor = 0x0001,
+
+        /// <summary>
+        /// Specifies all public constructors.
+        /// </summary>
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+
+        /// <summary>
+        /// Specifies all non-public constructors.
+        /// </summary>
+        NonPublicConstructors = 0x0004,
+
+        /// <summary>
+        /// Specifies all public methods.
+        /// </summary>
+        PublicMethods = 0x0008,
+
+        /// <summary>
+        /// Specifies all non-public methods.
+        /// </summary>
+        NonPublicMethods = 0x0010,
+
+        /// <summary>
+        /// Specifies all public fields.
+        /// </summary>
+        PublicFields = 0x0020,
+
+        /// <summary>
+        /// Specifies all non-public fields.
+        /// </summary>
+        NonPublicFields = 0x0040,
+
+        /// <summary>
+        /// Specifies all public nested types.
+        /// </summary>
+        PublicNestedTypes = 0x0080,
+
+        /// <summary>
+        /// Specifies all non-public nested types.
+        /// </summary>
+        NonPublicNestedTypes = 0x0100,
+
+        /// <summary>
+        /// Specifies all public properties.
+        /// </summary>
+        PublicProperties = 0x0200,
+
+        /// <summary>
+        /// Specifies all non-public properties.
+        /// </summary>
+        NonPublicProperties = 0x0400,
+
+        /// <summary>
+        /// Specifies all public events.
+        /// </summary>
+        PublicEvents = 0x0800,
+
+        /// <summary>
+        /// Specifies all non-public events.
+        /// </summary>
+        NonPublicEvents = 0x1000,
+
+        /// <summary>
+        /// Specifies all interfaces implemented by the type.
+        /// </summary>
+        Interfaces = 0x2000,
+
+        /// <summary>
+        /// Specifies all members.
+        /// </summary>
+        All = ~None
+    }
+#endif
+}

--- a/src/Sdk/Sdk.csproj
+++ b/src/Sdk/Sdk.csproj
@@ -4,10 +4,18 @@
     <RootNamespace>Passwordless.Net</RootNamespace>
     <AssemblyName>Passwordless.Net</AssemblyName>
     <PackageId>Passwordless</PackageId>
+    <TargetFrameworks>net462;net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IncludePreview)' == 'true'">$(TargetFrameworks);$(CurrentPreviewTfm)</TargetFrameworks>
     <Authors>Bitwarden</Authors>
     <RepositoryUrl>https://github.com/passwordless/passwordless-dotnet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PublishAot Condition=" '$(TargetFramework)' == 'net8.0'">true</PublishAot>
+  </PropertyGroup>
+
+  <!-- .NET 6 first introduced these types, for all others we include our own pollyfill so that it builds -->
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'net7.0' AND '$(TargetFramework)' != 'net8.0'">
+    <DefineConstants>$(DefineConstants);INCLUDE_DYNAMICALLY_ACCESSED_MEMBERS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,6 +27,11 @@
     <PackageReference Include="System.Text.Json" Version="7.0.3" />
     <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+    <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sdk/ServiceCollectionExtensions.cs
+++ b/src/Sdk/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using Microsoft.Extensions.Options;
 using Passwordless.Net;
@@ -36,7 +37,7 @@ public static class ServiceCollectionExtensions
     /// <remarks>
     /// This method signature is subject to change without major version bump/announcement.
     /// </remarks>
-    internal static IServiceCollection AddPasswordlessClientCore<TClient, TImplementation>(this IServiceCollection services, Action<IServiceProvider, HttpClient> configureClient)
+    internal static IServiceCollection AddPasswordlessClientCore<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TClient, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(this IServiceCollection services, Action<IServiceProvider, HttpClient> configureClient)
         where TClient : class
         where TImplementation : class, TClient
     {

--- a/tests/Sdk.Tests/ApiFactAttribute.cs
+++ b/tests/Sdk.Tests/ApiFactAttribute.cs
@@ -1,0 +1,13 @@
+#define RUNNING_API
+
+namespace Passwordless.Net.Tests;
+
+public class ApiFactAttribute : FactAttribute
+{
+    public ApiFactAttribute()
+    {
+#if !RUNNING_API
+        Skip = "These tests are skipped unless you are running the API locally.";
+#endif
+    }
+}

--- a/tests/Sdk.Tests/ApiFactAttribute.cs
+++ b/tests/Sdk.Tests/ApiFactAttribute.cs
@@ -1,4 +1,5 @@
-#define RUNNING_API
+// Uncomment line while running API in mock mode to run tests
+// #define RUNNING_API
 
 namespace Passwordless.Net.Tests;
 

--- a/tests/Sdk.Tests/PasswordlessClientTests.cs
+++ b/tests/Sdk.Tests/PasswordlessClientTests.cs
@@ -1,14 +1,12 @@
 using System.Net.Http;
+using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
+
 
 namespace Passwordless.Net.Tests;
 
 public class PasswordlessClientTests
 {
-
-    private const string SkipReason = "Manual test, you must be running the Api project.";
-    // private const string SkipReason = null;
-
     private readonly PasswordlessClient _sut;
 
     public PasswordlessClientTests()
@@ -26,39 +24,102 @@ public class PasswordlessClientTests
         _sut = (PasswordlessClient)provider.GetRequiredService<IPasswordlessClient>();
     }
 
-    [Fact(Skip = SkipReason)]
-    public async Task CreateRegisterToken_ThrowsExceptionWhenBad()
+    [ApiFact]
+    public async Task CreateRegisterTokenAsync_ThrowsExceptionWhenBad()
     {
         var exception = await Assert.ThrowsAnyAsync<HttpRequestException>(
             async () => await _sut.CreateRegisterTokenAsync(new RegisterOptions(null!, null!)));
     }
 
-    [Fact(Skip = SkipReason)]
-    public async Task VerifyToken_DoesNotThrowOnBadToken()
+    [ApiFact]
+    public async Task VerifyTokenAsync_DoesNotThrowOnBadToken()
     {
         var verifiedUser = await _sut.VerifyTokenAsync("bad_token");
 
         Assert.Null(verifiedUser);
     }
 
-    [Fact(Skip = SkipReason)]
+    [ApiFact]
     public async Task DeleteUserAsync_BadUserId_ThrowsException()
     {
         var exception = await Assert.ThrowsAnyAsync<HttpRequestException>(
             async () => await _sut.DeleteUserAsync(null!));
     }
 
-    [Fact(Skip = SkipReason)]
-    public async Task ListAsiases_BadUserId_ThrowsException()
+    [ApiFact]
+    public async Task ListAsiasesAsync_BadUserId_ThrowsException()
     {
         var exception = await Assert.ThrowsAnyAsync<HttpRequestException>(
             async () => await _sut.ListAliasesAsync(null!));
     }
 
-    [Fact(Skip = SkipReason)]
-    public async Task ListCredentials_BadUserId_ThrowsException()
+    [ApiFact]
+    public async Task ListCredentialsAsync_BadUserId_ThrowsException()
     {
-        var exception = await Assert.ThrowsAnyAsync<HttpRequestException>(
+        var exception = await Assert.ThrowsAnyAsync<PasswordlessApiException>(
             async () => await _sut.ListCredentialsAsync(null!));
+
+        var errorCode = Assert.Contains("errorCode", (IDictionary<string, JsonElement>)exception.Details.Extensions);
+        Assert.Equal(JsonValueKind.String, errorCode.ValueKind);
+        Assert.Equal("missing_userid", errorCode.GetString());
+    }
+
+    [ApiFact]
+    public async Task CreateRegisterTokenAsync_Works()
+    {
+        var userId = Guid.NewGuid().ToString();
+
+        var response = await _sut.CreateRegisterTokenAsync(new RegisterOptions(userId, "test_username"));
+
+        Assert.NotNull(response.Token);
+        Assert.StartsWith("register_", response.Token);
+    }
+
+    [ApiFact]
+    public async Task VerifyTokenAsync_Works()
+    {
+        var user = await _sut.VerifyTokenAsync("verify_valid");
+
+        Assert.NotNull(user);
+        Assert.True(user.Success);
+    }
+
+    [ApiFact]
+    public async Task ListUsersAsync_Works()
+    {
+        var users = await _sut.ListUsersAsync();
+
+        Assert.NotEmpty(users);
+    }
+
+    [ApiFact]
+    public async Task ListAliasesAsync_Works()
+    {
+        // Act
+        var aliases = await _sut.ListAliasesAsync("has_aliases");
+
+        // Assert
+        Assert.NotEmpty(aliases);
+    }
+
+    [ApiFact]
+    public async Task ListCredentialsAsync_Works()
+    {
+        var credentials = await _sut.ListCredentialsAsync("has_credentials");
+
+        Assert.NotEmpty(credentials);
+    }
+
+    [ApiFact]
+    public async Task DeleteCredentialAsync_Works()
+    {
+        await _sut.DeleteCredentialAsync("can_delete");
+    }
+
+    [ApiFact]
+    public async Task GetUsersCountAsync_Works()
+    {
+        var usersCount = await _sut.GetUsersCountAsync();
+        Assert.NotEqual(0, usersCount.Count);
     }
 }

--- a/tests/Sdk.Tests/Sdk.Tests.csproj
+++ b/tests/Sdk.Tests/Sdk.Tests.csproj
@@ -5,13 +5,15 @@
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Passwordless.Net.Tests</RootNamespace>
     <AssemblyName>Passwordless.Net.Tests</AssemblyName>
+    <TargetFrameworks>net6.0;net7.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludePreview)' == 'true'">$(TargetFrameworks);$(CurrentPreviewTfm)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Sdk.Tests/Sdk.Tests.csproj
+++ b/tests/Sdk.Tests/Sdk.Tests.csproj
@@ -5,7 +5,8 @@
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Passwordless.Net.Tests</RootNamespace>
     <AssemblyName>Passwordless.Net.Tests</AssemblyName>
-    <TargetFrameworks>net6.0;net7.0;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <TargetFrameworks Condition="'$(IncludePreview)' == 'true'">$(TargetFrameworks);$(CurrentPreviewTfm)</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
- Add more direct target frameworks
  - `netstandard2.0`, `net6.0` and only behind a opt-in property `net8.0`.
  - With `netstandard2.0` we get a computed framework of `net461`
  - With `net6.0` we support the current LTS version
  - With `net8.0` we get to be ready for using new goodies in preview
- Remove all anonymous types.
- Make all response types immutable.
  - This also removes nullable warnings that we were getting.
- Use JSON Source Generators
- Add more tests that fully cover `PasswordlessClient` and run against the API in a mock mode (not PR'ed yet).
