### PR TITLE
Add package metadata, sourcelink, inline docs, debug symbols, enable reproducible builds

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,10 @@ indent_style = space
 [*.xml]
 indent_size = 2
 
+# Csproj/fsproj/vbproj files
+[*.{csproj,fsproj,vbproj}]
+indent_size = 2
+
 # C# files
 [*.cs]
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,8 +8,8 @@ indent_style = space
 [*.xml]
 indent_size = 2
 
-# Csproj/fsproj/vbproj files
-[*.{csproj,fsproj,vbproj}]
+# Props/targets/Csproj/fsproj/vbproj files
+[*.{props,targets,csproj,fsproj,vbproj}]
 indent_size = 2
 
 # C# files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
         --configuration Release
         --no-build
         --output .
-        -p:ContinuousIntegrationBuild=true
 
     - name: Push to NuGet
       run: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         --configuration Release
         --no-build
         --output .
+        -p:ContinuousIntegrationBuild=true
 
     - name: Push to NuGet
       run: >

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -110,10 +110,7 @@ jobs:
           dotnet pack
           --no-build
           --configuration Release
-          --version-suffix "ci-${{ env.CLEAN_BRANCH_NAME }}-${{ github.run_id }}"
-          -p:ContinuousIntegrationBuild=true
-        env:
-          CLEAN_BRANCH_NAME: ${{needs.build-dotnet.outputs.clean_name}}
+          --version-suffix "ci-${{ needs.build-dotnet.outputs.clean_name }}-${{ github.run_id }}"
 
       - name: Publish NuGet Packages
         run: >

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -111,6 +111,7 @@ jobs:
           --no-build
           --configuration Release
           --version-suffix "ci-${{ env.CLEAN_BRANCH_NAME }}-${{ github.run_id }}"
+          -p:ContinuousIntegrationBuild=true
         env:
           CLEAN_BRANCH_NAME: ${{needs.build-dotnet.outputs.clean_name}}
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
     <CurrentPreviewTfm>net8.0</CurrentPreviewTfm>
     <!--<IncludePreview>true</IncludePreview>-->
     <IncludePreview Condition="'$(IncludePreview)' == ''">false</IncludePreview>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
     
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
     <WarningsAsErrors>nullable</WarningsAsErrors>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <IsPackable>false</IsPackable>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,13 +1,17 @@
 <Project>
-  <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
+
   <PropertyGroup>
     <CurrentPreviewTfm>net8.0</CurrentPreviewTfm>
     <!--<IncludePreview>true</IncludePreview>-->
     <IncludePreview Condition="'$(IncludePreview)' == ''">false</IncludePreview>
+  </PropertyGroup>
+    
+  <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -25,4 +29,5 @@
     -->
     <Using Remove="System.Net.Http" />
   </ItemGroup>
+
 </Project>

--- a/src/Passwordless/Passwordless.csproj
+++ b/src/Passwordless/Passwordless.csproj
@@ -3,15 +3,23 @@
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0;net7.0;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(IncludePreview)' == 'true'">$(TargetFrameworks);$(CurrentPreviewTfm)</TargetFrameworks>
+    <IsPackable>true</IsPackable>
     <PublishAot Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0'))">true</PublishAot>
   </PropertyGroup>
 
   <!-- Packaging-related properties -->
   <PropertyGroup>
     <Authors>Bitwarden</Authors>
-    <RepositoryUrl>https://github.com/passwordless/passwordless-dotnet</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
+    <Description>The official Bitwarden Passwordless.dev .NET library</Description>
+    <PackageProjectUrl>https://github.com/passwordless/passwordless-dotnet</PackageProjectUrl>
+    <PackageReleaseNotes>https://github.com/passwordless/passwordless-dotnet/releases</PackageReleaseNotes>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <!-- .NET 6 first introduced these types, for all others we include our own pollyfill so that it builds -->
@@ -22,6 +30,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
- Added some extra package metadata
- Enabled sourcelink (lets users of the library navigate directly to GitHub sources of various symbols)
- Enabled inline documentation (we already have inline docs, we were just not publishing them)
- Enabled embedded debug symbols (works better than publishing symbols separately)
- Enabled reproducible builds (ensures same source always produces the same binary, scrubs non-deterministic info)