### PR TITLE
Added ApiKey to the Options config

### DIFF
--- a/src/Passwordless.AspNetCore/IdentityBuilderExtensions.cs
+++ b/src/Passwordless.AspNetCore/IdentityBuilderExtensions.cs
@@ -97,6 +97,7 @@ public static class IdentityBuilderExtensions
                 var aspNetCoreOptions = aspNetCoreOptionsAccessor.Value;
                 options.ApiSecret = aspNetCoreOptions.ApiSecret;
                 options.ApiUrl = aspNetCoreOptions.ApiUrl;
+                options.ApiKey = aspNetCoreOptions.ApiKey;
             });
 
         return services;


### PR DESCRIPTION
This will set ApiKey on the PasswordlessOptions object that's injected into the IServiceCollection.