### PR TITLE
Remove little icons from readme headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="favicon.png" width="24" height="24" alt="Icon" /> Passwordless .NET SDK
+# Passwordless .NET SDK
 
 The official [Bitwarden Passwordless.dev](https://passwordless.dev) .NET library, supporting .NET Standard 2.0+, .NET Core 2.0+, and .NET Framework 4.6.2+.
 

--- a/src/Passwordless.AspNetCore/README.md
+++ b/src/Passwordless.AspNetCore/README.md
@@ -1,4 +1,4 @@
-# <img src="../../favicon.png" width="24" height="24" alt="Icon" /> Passwordless ASP.NET Core Integration 
+# Passwordless ASP.NET Core Integration 
 
 The official [Bitwarden Passwordless.dev](https://passwordless.dev) ASP.NET Identity integration. Automatically adds endpoints to verify passwordless signin and sign the user in using the existing ASP.NET Identity code.
 


### PR DESCRIPTION
It doesn't work on NuGet.org readme preview