### PR TITLE
Add bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -29,6 +29,13 @@ jobs:
           version=$(echo "$props_file" | grep -oPm1 "(?<=<Version>)[^<]+")
           echo "version=$version" >> $GITHUB_OUTPUT
 
+      - name: Validate new version
+        run: |
+          if npx semver "${{ inputs.version }}" --range "<= ${{ steps.current-version.outputs.version }}"; then
+            echo "New version must be greater than the current version"
+            exit 1
+          fi
+
   # Update version and commit
   update:
     needs: validate

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -31,8 +31,7 @@ jobs:
 
       - name: Validate new version
         run: >
-          npx semver@7.5.4
-          "${{ inputs.version }}"
+          npx semver@7.5.4 "${{ inputs.version }}"
           --range "> ${{ steps.current-version.outputs.version }}"
           --include-prerelease
 

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -30,11 +30,10 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Validate new version
-        run: |
-          if npx semver "${{ inputs.version }}" --range "<= ${{ steps.current-version.outputs.version }}"; then
-            echo "New version must be greater than the current version"
-            exit 1
-          fi
+        run: >
+          npx semver "${{ inputs.version }}"
+          --range "> ${{ steps.current-version.outputs.version }}"
+          --include-prerelease
 
   # Update version and commit
   update:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -31,7 +31,8 @@ jobs:
 
       - name: Validate new version
         run: >
-          npx semver "${{ inputs.version }}"
+          npx semver@7.5.4
+          "${{ inputs.version }}"
           --range "> ${{ steps.current-version.outputs.version }}"
           --include-prerelease
 

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -26,7 +26,7 @@ jobs:
         id: current-version
         run: |
           props_file=$(cat Directory.Build.props)
-          version=$(echo "$props_file" | grep -oPm1 "(?<=<Version>)[^<]+")
+          version=$(echo "$props_file" | grep -oPm1 "(?<=<Version>)[^<]*")
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Validate new version
@@ -56,7 +56,7 @@ jobs:
         run: git checkout -b $BUMP_BRANCH_NAME
 
       - name: Rewrite version
-        run: sed -i "s/<Version>[^<]*<\/Version>/<Version>${{ inputs.version }}<\/Version>/" Directory.Build.props
+        run: sed -i "s/<Version>[^<]*/<Version>${{ inputs.version }}/" Directory.Build.props
 
       - name: Commit changes
         run: |

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -74,6 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,82 @@
+name: bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
+        description: Version to bump to
+
+env:
+  BUMP_BRANCH_NAME: bump-${{ inputs.version }}-${{ github.run_id }}
+
+jobs:
+  # Ensure that the provided version is greater than the current version
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - name: Get current version
+        id: current-version
+        run: |
+          props_file=$(cat Directory.Build.props)
+          version=$(echo "$props_file" | grep -oPm1 "(?<=<Version>)[^<]+")
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+  # Update version and commit
+  update:
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - name: Configure credentials
+        run: |
+          git config --local user.email "106330231+passwordless-bot@users.noreply.github.com"
+          git config --local user.name "passwordless-bot"
+
+      - name: Create branch
+        run: git checkout -b $BUMP_BRANCH_NAME
+
+      - name: Rewrite version
+        run: sed -i "s/<Version>[^<]*<\/Version>/<Version>${{ inputs.version }}<\/Version>/" Directory.Build.props
+
+      - name: Commit changes
+        run: |
+          git add Directory.Build.props
+          git commit -m "Bump version to ${{ inputs.version }}"
+
+      - name: Push changes
+        run: git push origin $BUMP_BRANCH_NAME
+
+  # Create a pull request
+  pr:
+    needs:
+      - validate
+      - update
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - name: Create pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          gh pr create
+          --base main
+          --head $BUMP_BRANCH_NAME
+          --title "Bump version to ${{ inputs.version }}"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Get current version
         id: current-version
         run: |
-          props_file=$(cat Directory.Build.props)
-          version=$(echo "$props_file" | grep -oPm1 "(?<=<Version>)[^<]*")
+          props=$(cat Directory.Build.props)
+          version=$(echo "$props" | grep -oPm1 "(?<=<Version>)[^<]*")
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Validate new version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,9 +123,10 @@ jobs:
         id: prerelease-version
         if: ${{ github.event_name != 'release' }}
         run: |
+          time=$(date +%s)
           ref="${{ github.head_ref || github.ref_name }}"
           ref_clean="${ref/\//-}"
-          suffix="ci-$ref_clean-${{ github.run_id }}"
+          suffix="ci-$time-$ref_clean-${{ github.run_id }}"
           echo "version=0.0.0-$suffix" >> $GITHUB_OUTPUT
 
       - name: Run pack

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,8 +125,8 @@ jobs:
         run: |
           ref="${{ github.head_ref || github.ref_name }}"
           ref_clean="${ref/\//-}"
-          suffix="ci-${ref_clean}-${{ github.run_id }}"
-          echo "suffix=${suffix}" >> $GITHUB_OUTPUT
+          suffix="ci-$ref_clean-${{ github.run_id }}"
+          echo "version=0.0.0-$suffix" >> $GITHUB_OUTPUT
 
       - name: Run pack
         run: >
@@ -135,7 +135,7 @@ jobs:
           --no-build
           --configuration Release
           -p:ContinuousIntegrationBuild=true
-          ${{ steps.prerelease-version.outputs.suffix && format('--version-suffix {0}', steps.prerelease-version.outputs.suffix) || '' }}
+          ${{ steps.prerelease-version.outputs.version && format('-p:Version={0}', steps.prerelease-version.outputs.version) || '' }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
 
   <PropertyGroup>
+    <Version>2.0.0-beta1</Version>
     <CurrentPreviewTfm>net8.0</CurrentPreviewTfm>
     <!--<IncludePreview>true</IncludePreview>-->
     <IncludePreview Condition="'$(IncludePreview)' == ''">false</IncludePreview>
@@ -13,15 +14,6 @@
     <WarningsAsErrors>nullable</WarningsAsErrors>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <PasswordlessMajorVersion>2</PasswordlessMajorVersion>
-    <PasswordlessMinorVersion>0</PasswordlessMinorVersion>
-    <PasswordlessPatchVersion>0</PasswordlessPatchVersion>
-    <PasswordlessMajorMinorVersion>$(PasswordlessMajorVersion).$(PasswordlessMinorVersion)</PasswordlessMajorMinorVersion>
-    <VersionPrefix>$(PasswordlessMajorMinorVersion).$(PasswordlessPatchVersion)</VersionPrefix>
-    <VersionSuffix>beta1</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This adds a new, dispatchable workflow called `bump`. You can use it to update the current package version (of both `Passwordless` and `Passwordless.AspNetCore`). It does that by updating `Directory.Build.props`, committing changes to a new branch, and then creating a pull request. Very similar to what @abergs did in #27.

In order to facilitate this workflow, I also took the liberty of performing one additional breaking change: auto-generated prerelease package versions for CI deployments now follow the pattern of `0.0.0-ci-BRANCH-RUNID`. The main difference is that the version is always `0.0.0`.

This change was done so that we could consolidate both `VersionPrefix` and `VersionSuffix` into a single `Version` property. It's not essential for this workflow to work, but then instead of one input it would likely take two (which is not a catastrophe).

However, here are some advantages to this versioning schema:
- Previously, auto-generated prerelease version was attached to the _current version prefix_. That means, if `Passwordless` version `2.0.0` was already released, all subsequent CI builds would push a package with a version like `2.0.0-ci-main-12345`. This meant that, in terms of semantic versioning, they appeared older than the stable `2.0.0` package, which was actually released earlier.
  - This could be resolved by bumping the package version preemptively, right after a release. In other words, right after `2.0.0` is released, we would update the current version to `2.0.1` or something. The issue here is that we can't know ahead of time which component we should be bumping. The prerelease versions will be ordered correctly this way, but it feels weird to have a semantic version that's not actually semantic.
  - Not bumping preemptively has the added benefit of preventing us from accidentally releasing a version that's not ready for release. For example if we just released `2.0.0` and some workflow or user error resulted in another deployment of that package, it would fail because versions are immutable. However, if we preemptively bumped the version to `2.0.1`, the erroneous deployment would go through.
  - For reasons above, I believe `0.0.0-ci-BRANCH-RUNID` is a better naming schema. However, we might want to prepend the suffix with the current unix timestamp to make sure the prerelease versions are also ordered correctly between themselves.

Again, if the version change is undesired, I can revert that part and change the `bump` workflow to take two inputs instead of one.