### PR TITLE
Notify Slack on successful release deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,5 +198,5 @@ jobs:
             Content-Type: application/json; charset=UTF-8
           body: |
             {
-              "text": "**${{ github.event.repository.name }}** new version released!\nVersion: `${{ github.event.release.name }}`\nDetails: <${{ github.event.release.html_url }}>"
+              "text": "Passwordless.NET new version released!\nVersion: `${{ github.event.release.name }}`\nDetails: ${{ github.event.release.html_url }}"
             }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,3 +181,22 @@ jobs:
           dotnet nuget push **/*.nupkg
           --source https://api.nuget.org/v3/index.json
           --api-key ${{ secrets.nuget_api_key }}
+
+  # Notify the Slack channel about the release
+  notify:
+    if: ${{ github.event_name == 'release' }}
+    needs: deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send Slack message
+        uses: tyrrrz/action-http-request@28a403e52ea0f292b85a1850aeab1b90abc54be0 # 1.0.0
+        with:
+          url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          method: POST
+          headers: |
+            Content-Type: application/json; charset=UTF-8
+          body: |
+            {
+              "text": "**${{ github.event.repository.name }}** new version released!\nVersion: `${{ github.event.release.name }}`\nDetails: <${{ github.event.release.html_url }}>"
+            }


### PR DESCRIPTION
This sends a message in Slack on successful stable release deployment, with the following content:

```
Passwordless.NET new version released!
Version: 1.0.2
Details: https://github.com/passwordless/passwordless-dotnet/releases/tag/v1.0.2
```